### PR TITLE
add new sensitivity attribute to blocks

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -76,6 +76,11 @@ type Block struct {
 	Content []Block `json:"content,omitempty" proto:"14"`
 	// Meta is used to embed metadata
 	Meta []Block `json:"meta,omitempty" proto:"15"`
+	// Sensitivity can be use to communicate how the information in a block
+	// can be handled. It could f.ex. be set to "internal", to show that it
+	// contains information that must be removed or transformed before
+	// publishing.
+	Sensitivity string `json:"sensitivity,omitempty" proto:"16"`
 }
 
 // DataMap is used as key -> (string) value data for blocks.

--- a/newsdoc.proto
+++ b/newsdoc.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package newsdoc;
 
+
+
 // Document is a NewsDoc document.
 message Document {
   // UUID is a unique ID for the document, this can for example be a
@@ -71,6 +73,11 @@ message Block {
   repeated Block content = 14;
   // Meta is used to embed metadata
   repeated Block meta = 15;
+  // Sensitivity can be use to communicate how the information in a block
+  // can be handled. It could f.ex. be set to "internal", to show that it
+  // contains information that must be removed or transformed before
+  // publishing.
+  string sensitivity = 16;
 }
 
 

--- a/newsdoc.schema.json
+++ b/newsdoc.schema.json
@@ -76,6 +76,10 @@
           },
           "type": "array",
           "description": "Meta is used to embed metadata"
+        },
+        "sensitivity": {
+          "type": "string",
+          "description": "Sensitivity can be use to communicate how the information in a block can be handled. It could f.ex. be set to \"internal\", to show that it contains information that must be removed or transformed before publishing."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
I think that sensitivity tagging should be a core concept in our data stack. This would allow us to build out automation that will let us publish content/data with confidence that all sensitive information is removed/transformed before publishing.