### PR TITLE
feat(value-extractor): add inline child selector '#(...)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,14 @@ The terminal `#` form above consumes the rest of the expression as a child chain
 
 This matches `core/assignment` meta blocks that have a `deliverable` link, then navigates into each match's `tt/slugline` meta block and extracts the `value` attribute. The inline form can appear on any selector in the chain and supports the same nested filters as the terminal form.
 
+The terminal `#` is just shorthand for an inline `#(...)` on the last selector, so the two forms share one mechanism. A selector may carry several gates — any mix of inline `#(...)` clauses and a trailing terminal `#` — and the block matches only if *every* gate is satisfied:
+
+```
+.meta(type='core/assignment')#(.links(rel='deliverable'))#(.meta(type='tt/slugline'))
+```
+
+This matches assignments that have both a `deliverable` link and a `tt/slugline` meta block.
+
 ### Extracting data values
 
 Use `.data{}` to extract values from the matched blocks' data maps. Values are space-separated (commas are also accepted):

--- a/README.md
+++ b/README.md
@@ -240,6 +240,14 @@ Child selectors can be chained to match deeper descendants, and support the same
 assignment=.meta(type='core/assignment')#.links(rel='deliverable' data.status='active'):label
 ```
 
+The terminal `#` form above consumes the rest of the expression as a child chain, so the outer selector cannot continue past it. To constrain a single selector by its descendants while still navigating further, attach an inline `#(...)` clause directly to that selector:
+
+```
+.meta(type='core/assignment')#(.links(rel='deliverable')).meta(type='tt/slugline')@{value}
+```
+
+This matches `core/assignment` meta blocks that have a `deliverable` link, then navigates into each match's `tt/slugline` meta block and extracts the `value` attribute. The inline form can appear on any selector in the chain and supports the same nested filters as the terminal form.
+
 ### Extracting data values
 
 Use `.data{}` to extract values from the matched blocks' data maps. Values are space-separated (commas are also accepted):

--- a/testdata/TestValueExtractorParse/child_selector.json
+++ b/testdata/TestValueExtractorParse/child_selector.json
@@ -1,29 +1,31 @@
 {
-  "ChildSelectors": [
-    {
-      "Filter": {
-        "Children": [
-          {
-            "Attr": "rel",
-            "Value": "deliverable"
-          },
-          {
-            "Attr": "uuid",
-            "Value": "abc"
-          }
-        ],
-        "Op": "and"
-      },
-      "Kind": "links"
-    }
-  ],
   "Selectors": [
     {
       "Filter": {
         "Attr": "type",
         "Value": "core/assignment"
       },
-      "Kind": "meta"
+      "Kind": "meta",
+      "RequireChild": [
+        [
+          {
+            "Filter": {
+              "Children": [
+                {
+                  "Attr": "rel",
+                  "Value": "deliverable"
+                },
+                {
+                  "Attr": "uuid",
+                  "Value": "abc"
+                }
+              ],
+              "Op": "and"
+            },
+            "Kind": "links"
+          }
+        ]
+      ]
     }
   ],
   "ValueKind": "block",

--- a/testdata/TestValueExtractorParse/double_terminal_hash.json
+++ b/testdata/TestValueExtractorParse/double_terminal_hash.json
@@ -15,6 +15,15 @@
             },
             "Kind": "links"
           }
+        ],
+        [
+          {
+            "Filter": {
+              "Attr": "type",
+              "Value": "c"
+            },
+            "Kind": "content"
+          }
         ]
       ]
     }

--- a/testdata/TestValueExtractorParse/inline_child_end_of_chain.json
+++ b/testdata/TestValueExtractorParse/inline_child_end_of_chain.json
@@ -1,0 +1,26 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b"
+          },
+          "Kind": "links"
+        }
+      ]
+    }
+  ],
+  "ValueKind": "data",
+  "Values": [
+    {
+      "Name": "x"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_multi_level.json
+++ b/testdata/TestValueExtractorParse/inline_child_multi_level.json
@@ -7,20 +7,22 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "type",
-            "Value": "b"
+        [
+          {
+            "Filter": {
+              "Attr": "type",
+              "Value": "b"
+            },
+            "Kind": "meta"
           },
-          "Kind": "meta"
-        },
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "c"
-          },
-          "Kind": "links"
-        }
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "c"
+            },
+            "Kind": "links"
+          }
+        ]
       ]
     }
   ],

--- a/testdata/TestValueExtractorParse/inline_child_multi_level.json
+++ b/testdata/TestValueExtractorParse/inline_child_multi_level.json
@@ -1,0 +1,33 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "type",
+            "Value": "b"
+          },
+          "Kind": "meta"
+        },
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "c"
+          },
+          "Kind": "links"
+        }
+      ]
+    }
+  ],
+  "ValueKind": "data",
+  "Values": [
+    {
+      "Name": "x"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_multiple.json
+++ b/testdata/TestValueExtractorParse/inline_child_multiple.json
@@ -1,0 +1,42 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b"
+          },
+          "Kind": "links"
+        }
+      ]
+    },
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "c"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "type",
+            "Value": "d"
+          },
+          "Kind": "content"
+        }
+      ]
+    }
+  ],
+  "ValueKind": "data",
+  "Values": [
+    {
+      "Name": "x"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_multiple.json
+++ b/testdata/TestValueExtractorParse/inline_child_multiple.json
@@ -7,13 +7,15 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "b"
-          },
-          "Kind": "links"
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "b"
+            },
+            "Kind": "links"
+          }
+        ]
       ]
     },
     {
@@ -23,13 +25,15 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "type",
-            "Value": "d"
-          },
-          "Kind": "content"
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "type",
+              "Value": "d"
+            },
+            "Kind": "content"
+          }
+        ]
       ]
     }
   ],

--- a/testdata/TestValueExtractorParse/inline_child_nested.json
+++ b/testdata/TestValueExtractorParse/inline_child_nested.json
@@ -7,22 +7,26 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "b"
-          },
-          "Kind": "links",
-          "RequireChild": [
-            {
-              "Filter": {
-                "Attr": "type",
-                "Value": "c"
-              },
-              "Kind": "meta"
-            }
-          ]
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "b"
+            },
+            "Kind": "links",
+            "RequireChild": [
+              [
+                {
+                  "Filter": {
+                    "Attr": "type",
+                    "Value": "c"
+                  },
+                  "Kind": "meta"
+                }
+              ]
+            ]
+          }
+        ]
       ]
     }
   ],

--- a/testdata/TestValueExtractorParse/inline_child_nested.json
+++ b/testdata/TestValueExtractorParse/inline_child_nested.json
@@ -1,0 +1,35 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b"
+          },
+          "Kind": "links",
+          "RequireChild": [
+            {
+              "Filter": {
+                "Attr": "type",
+                "Value": "c"
+              },
+              "Kind": "meta"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "ValueKind": "data",
+  "Values": [
+    {
+      "Name": "x"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_quoted_hash.json
+++ b/testdata/TestValueExtractorParse/inline_child_quoted_hash.json
@@ -1,0 +1,26 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b#c"
+          },
+          "Kind": "links"
+        }
+      ]
+    }
+  ],
+  "ValueKind": "data",
+  "Values": [
+    {
+      "Name": "x"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_quoted_hash.json
+++ b/testdata/TestValueExtractorParse/inline_child_quoted_hash.json
@@ -7,13 +7,15 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "b#c"
-          },
-          "Kind": "links"
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "b#c"
+            },
+            "Kind": "links"
+          }
+        ]
       ]
     }
   ],

--- a/testdata/TestValueExtractorParse/inline_child_quoted_paren.json
+++ b/testdata/TestValueExtractorParse/inline_child_quoted_paren.json
@@ -1,0 +1,26 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b)c"
+          },
+          "Kind": "links"
+        }
+      ]
+    }
+  ],
+  "ValueKind": "data",
+  "Values": [
+    {
+      "Name": "x"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_quoted_paren.json
+++ b/testdata/TestValueExtractorParse/inline_child_quoted_paren.json
@@ -7,13 +7,15 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "b)c"
-          },
-          "Kind": "links"
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "b)c"
+            },
+            "Kind": "links"
+          }
+        ]
       ]
     }
   ],

--- a/testdata/TestValueExtractorParse/inline_child_then_attrs.json
+++ b/testdata/TestValueExtractorParse/inline_child_then_attrs.json
@@ -1,0 +1,33 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b"
+          },
+          "Kind": "links"
+        }
+      ]
+    },
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "c"
+      },
+      "Kind": "meta"
+    }
+  ],
+  "ValueKind": "attributes",
+  "Values": [
+    {
+      "Name": "value"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_then_attrs.json
+++ b/testdata/TestValueExtractorParse/inline_child_then_attrs.json
@@ -7,13 +7,15 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "b"
-          },
-          "Kind": "links"
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "b"
+            },
+            "Kind": "links"
+          }
+        ]
       ]
     },
     {

--- a/testdata/TestValueExtractorParse/inline_child_then_data.json
+++ b/testdata/TestValueExtractorParse/inline_child_then_data.json
@@ -1,0 +1,33 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b"
+          },
+          "Kind": "links"
+        }
+      ]
+    },
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "c"
+      },
+      "Kind": "meta"
+    }
+  ],
+  "ValueKind": "data",
+  "Values": [
+    {
+      "Name": "x"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_then_data.json
+++ b/testdata/TestValueExtractorParse/inline_child_then_data.json
@@ -7,13 +7,15 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "b"
-          },
-          "Kind": "links"
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "b"
+            },
+            "Kind": "links"
+          }
+        ]
       ]
     },
     {

--- a/testdata/TestValueExtractorParse/inline_child_two_gates.json
+++ b/testdata/TestValueExtractorParse/inline_child_two_gates.json
@@ -15,6 +15,15 @@
             },
             "Kind": "links"
           }
+        ],
+        [
+          {
+            "Filter": {
+              "Attr": "type",
+              "Value": "c"
+            },
+            "Kind": "content"
+          }
         ]
       ]
     }

--- a/testdata/TestValueExtractorParse/inline_child_with_name_annot.json
+++ b/testdata/TestValueExtractorParse/inline_child_with_name_annot.json
@@ -7,13 +7,15 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "b"
-          },
-          "Kind": "links"
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "b"
+            },
+            "Kind": "links"
+          }
+        ]
       ]
     }
   ],

--- a/testdata/TestValueExtractorParse/inline_child_with_name_annot.json
+++ b/testdata/TestValueExtractorParse/inline_child_with_name_annot.json
@@ -1,0 +1,27 @@
+{
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b"
+          },
+          "Kind": "links"
+        }
+      ]
+    }
+  ],
+  "ValueKind": "block",
+  "Values": [
+    {
+      "Annotation": "annot",
+      "Name": "pick"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_with_terminal.json
+++ b/testdata/TestValueExtractorParse/inline_child_with_terminal.json
@@ -1,0 +1,35 @@
+{
+  "ChildSelectors": [
+    {
+      "Filter": {
+        "Attr": "rel",
+        "Value": "d"
+      },
+      "Kind": "links"
+    }
+  ],
+  "Selectors": [
+    {
+      "Filter": {
+        "Attr": "type",
+        "Value": "a"
+      },
+      "Kind": "meta",
+      "RequireChild": [
+        {
+          "Filter": {
+            "Attr": "rel",
+            "Value": "b"
+          },
+          "Kind": "links"
+        }
+      ]
+    }
+  ],
+  "ValueKind": "data",
+  "Values": [
+    {
+      "Name": "x"
+    }
+  ]
+}

--- a/testdata/TestValueExtractorParse/inline_child_with_terminal.json
+++ b/testdata/TestValueExtractorParse/inline_child_with_terminal.json
@@ -1,13 +1,4 @@
 {
-  "ChildSelectors": [
-    {
-      "Filter": {
-        "Attr": "rel",
-        "Value": "d"
-      },
-      "Kind": "links"
-    }
-  ],
   "Selectors": [
     {
       "Filter": {
@@ -16,13 +7,24 @@
       },
       "Kind": "meta",
       "RequireChild": [
-        {
-          "Filter": {
-            "Attr": "rel",
-            "Value": "b"
-          },
-          "Kind": "links"
-        }
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "b"
+            },
+            "Kind": "links"
+          }
+        ],
+        [
+          {
+            "Filter": {
+              "Attr": "rel",
+              "Value": "d"
+            },
+            "Kind": "links"
+          }
+        ]
       ]
     }
   ],

--- a/value_extractor.go
+++ b/value_extractor.go
@@ -9,10 +9,9 @@ import (
 )
 
 type ValueExtractor struct {
-	Selectors      []BlockSelector
-	ChildSelectors []BlockSelector `json:",omitempty"`
-	ValueKind      ValueKind
-	Values         []ValueSpec
+	Selectors []BlockSelector
+	ValueKind ValueKind
+	Values    []ValueSpec
 }
 
 var (
@@ -252,17 +251,16 @@ func ValueExtractorFromBytes(text []byte) (*ValueExtractor, error) {
 		}}
 	}
 
-	// Terminal '#' may appear in the selector chain or after the value spec's
-	// '}'. Only the terminal form is allowed after '}'.
-	var childSelector []byte
+	// A terminal '#' may appear both in the selector chain and after the
+	// value spec's '}' (only the terminal form is allowed there). Each one is
+	// folded into a RequireChild chain on the last selector, exactly as if it
+	// were an inline '#(...)' attached to that selector. Collect them in order
+	// so neither gate is lost when both are present.
+	var terminalChildren [][]byte
 
 	if hashIdx := terminalHashIndex(selector); hashIdx != -1 {
-		childSelector = selector[hashIdx+1:]
+		terminalChildren = append(terminalChildren, selector[hashIdx+1:])
 		selector = selector[:hashIdx]
-
-		if len(bytes.TrimSpace(childSelector)) == 0 {
-			return nil, fmt.Errorf("empty child selector after '#'")
-		}
 	}
 
 	trimmedSuffix := bytes.TrimSpace(valueSpecSuffix)
@@ -277,10 +275,7 @@ func ValueExtractorFromBytes(text []byte) (*ValueExtractor, error) {
 				"inline child selector '#(...)' is not allowed after a value spec")
 		}
 
-		childSelector = trimmedSuffix[1:]
-		if len(bytes.TrimSpace(childSelector)) == 0 {
-			return nil, fmt.Errorf("empty child selector after '#'")
-		}
+		terminalChildren = append(terminalChildren, trimmedSuffix[1:])
 	}
 
 	selectors, err := parseSelectors(selector)
@@ -290,17 +285,27 @@ func ValueExtractorFromBytes(text []byte) (*ValueExtractor, error) {
 
 	ve.Selectors = selectors
 
-	if len(childSelector) > 0 {
-		childSelectors, err := parseSelectors(childSelector)
+	if len(terminalChildren) > 0 && len(ve.Selectors) == 0 {
+		return nil, fmt.Errorf(
+			"terminal '#' child selector requires a parent selector")
+	}
+
+	for _, childSelector := range terminalChildren {
+		if len(bytes.TrimSpace(childSelector)) == 0 {
+			return nil, fmt.Errorf("empty child selector after '#'")
+		}
+
+		childChain, err := parseSelectors(childSelector)
 		if err != nil {
 			return nil, fmt.Errorf("child selectors: %w", err)
 		}
 
-		if len(childSelectors) == 0 {
+		if len(childChain) == 0 {
 			return nil, fmt.Errorf("empty child selector after '#'")
 		}
 
-		ve.ChildSelectors = childSelectors
+		last := &ve.Selectors[len(ve.Selectors)-1]
+		last.RequireChild = append(last.RequireChild, childChain)
 	}
 
 	if ve.ValueKind == ValueKindBlock {
@@ -371,23 +376,6 @@ func (ve *ValueExtractor) Collect(doc Document) []ExtractedItems {
 		}
 
 		matches = sel.Iterator(concatIter(srcBlocks...))
-	}
-
-	if len(ve.ChildSelectors) > 0 {
-		childSelectors := ve.ChildSelectors
-		prev := matches
-
-		matches = func(yield func(Block) bool) {
-			for b := range prev {
-				if !hasMatchingChildren(b, childSelectors) {
-					continue
-				}
-
-				if !yield(b) {
-					return
-				}
-			}
-		}
 	}
 
 	var extracts []ExtractedItems
@@ -756,13 +744,14 @@ func (fn *FilterNode) Matches(b Block) bool {
 }
 
 // BlockSelector selects blocks by kind and optional attribute/data filters.
-// RequireChild (the inline '#(...)' form) gates the parent on a descendant
-// chain without yielding it, unlike ValueExtractor.ChildSelectors which
-// terminates the outer chain and yields the descendants.
+// RequireChild holds zero or more independent descendant chains that must ALL
+// match (logical AND); each chain is an existence check that yields the matched
+// block itself, never its descendants. The inline '#(...)' form and the
+// terminal '#' form each append one chain.
 type BlockSelector struct {
 	Kind         BlockKind
-	Filter       *FilterNode     `json:",omitempty"`
-	RequireChild []BlockSelector `json:",omitempty"`
+	Filter       *FilterNode       `json:",omitempty"`
+	RequireChild [][]BlockSelector `json:",omitempty"`
 }
 
 func (bs BlockSelector) Iterator(blocks iter.Seq[Block]) iter.Seq[Block] {
@@ -849,8 +838,10 @@ func (bs BlockSelector) Matches(b Block) bool {
 		return false
 	}
 
-	if len(bs.RequireChild) > 0 && !hasMatchingChildren(b, bs.RequireChild) {
-		return false
+	for _, chain := range bs.RequireChild {
+		if !hasMatchingChildren(b, chain) {
+			return false
+		}
 	}
 
 	return true
@@ -1291,7 +1282,8 @@ func parseSelectors(s []byte) ([]BlockSelector, error) {
 	return selectors, nil
 }
 
-// parseSelectorPart parses: kind [ '(' filter ')' ] [ '#(' childChain ')' ].
+// parseSelectorPart parses: kind [ '(' filter ')' ] { '#(' childChain ')' },
+// where any number of inline '#(...)' child gates may follow.
 func parseSelectorPart(part []byte) (BlockSelector, error) {
 	if len(part) == 0 {
 		return BlockSelector{}, fmt.Errorf(
@@ -1336,24 +1328,21 @@ func parseSelectorPart(part []byte) (BlockSelector, error) {
 		rest = rest[closeIdx+1:]
 	}
 
-	if len(rest) > 0 {
+	// Consume any number of inline '#(...)' child gates; each appends one
+	// descendant chain that the block must satisfy.
+	for len(rest) > 0 {
 		if rest[0] != '#' {
 			return BlockSelector{}, fmt.Errorf(
 				"unexpected trailing content in selector %q: %q", part, rest)
 		}
 
-		childSelectors, after, err := parseInlineChildSelector(rest)
+		childChain, after, err := parseInlineChildSelector(rest)
 		if err != nil {
 			return BlockSelector{}, fmt.Errorf("in selector %q: %w", part, err)
 		}
 
-		selector.RequireChild = childSelectors
+		selector.RequireChild = append(selector.RequireChild, childChain)
 		rest = after
-	}
-
-	if len(rest) > 0 {
-		return BlockSelector{}, fmt.Errorf(
-			"unexpected trailing content in selector %q: %q", part, rest)
 	}
 
 	return selector, nil

--- a/value_extractor.go
+++ b/value_extractor.go
@@ -16,18 +16,17 @@ type ValueExtractor struct {
 }
 
 var (
-	dataPrefix  = []byte(".data{")
-	attrPrefix  = []byte("@{")
-	bPeriod     = []byte(".")
-	bStartParen = []byte("(")
-	bEndParen   = []byte(")")
-	bEqual      = []byte("=")
-	bComma      = []byte(",")
-	bColon      = []byte(":")
-	bQMark      = []byte("?")
-	bDataDot    = []byte("data.")
-	bQuote      = byte('\'')
-	bBackslash  = byte('\\')
+	dataPrefix = []byte(".data{")
+	attrPrefix = []byte("@{")
+	bPeriod    = []byte(".")
+	bEndParen  = []byte(")")
+	bEqual     = []byte("=")
+	bComma     = []byte(",")
+	bColon     = []byte(":")
+	bQMark     = []byte("?")
+	bDataDot   = []byte("data.")
+	bQuote     = byte('\'')
+	bBackslash = byte('\\')
 )
 
 // findClosingQuote returns the index of the closing single quote in s,
@@ -69,20 +68,37 @@ func unescapeQuoted(s []byte) []byte {
 	return out
 }
 
-// indexByteOutsideQuotes returns the index of the first occurrence of c in s
-// that is not inside a single-quoted string, or -1 if not found.
-func indexByteOutsideQuotes(s []byte, c byte) int {
+// terminalHashIndex returns the index of the first '#' in s that terminates
+// the outer selector chain: at paren depth zero, outside quotes, and not
+// followed by '(' (the inline form). Returns -1 if none, or on unterminated
+// quote.
+func terminalHashIndex(s []byte) int {
+	depth := 0
+
 	for i := 0; i < len(s); i++ {
-		if s[i] == bQuote {
+		switch s[i] {
+		case bQuote:
 			end := findClosingQuote(s[i+1:])
-			if end != -1 {
-				i += end + 1
+			if end == -1 {
+				return -1
 			}
 
-			continue
-		}
+			i += end + 1
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case '#':
+			if depth != 0 {
+				continue
+			}
 
-		if s[i] == c {
+			if i+1 < len(s) && s[i+1] == '(' {
+				continue
+			}
+
 			return i
 		}
 	}
@@ -236,18 +252,35 @@ func ValueExtractorFromBytes(text []byte) (*ValueExtractor, error) {
 		}}
 	}
 
-	// Split parent and child selectors on '#', skipping '#' inside
-	// single-quoted attribute values. The '#' can appear either in the
-	// selector chain or after the value spec's closing '}'.
+	// Terminal '#' may appear in the selector chain or after the value spec's
+	// '}'. Only the terminal form is allowed after '}'.
 	var childSelector []byte
 
-	if hashIdx := indexByteOutsideQuotes(selector, '#'); hashIdx != -1 {
+	if hashIdx := terminalHashIndex(selector); hashIdx != -1 {
 		childSelector = selector[hashIdx+1:]
 		selector = selector[:hashIdx]
+
+		if len(bytes.TrimSpace(childSelector)) == 0 {
+			return nil, fmt.Errorf("empty child selector after '#'")
+		}
 	}
 
-	if hashIdx := indexByteOutsideQuotes(valueSpecSuffix, '#'); hashIdx != -1 {
-		childSelector = valueSpecSuffix[hashIdx+1:]
+	trimmedSuffix := bytes.TrimSpace(valueSpecSuffix)
+	if len(trimmedSuffix) > 0 {
+		if trimmedSuffix[0] != '#' {
+			return nil, fmt.Errorf(
+				"unexpected content after value spec: %q", trimmedSuffix)
+		}
+
+		if len(trimmedSuffix) >= 2 && trimmedSuffix[1] == '(' {
+			return nil, fmt.Errorf(
+				"inline child selector '#(...)' is not allowed after a value spec")
+		}
+
+		childSelector = trimmedSuffix[1:]
+		if len(bytes.TrimSpace(childSelector)) == 0 {
+			return nil, fmt.Errorf("empty child selector after '#'")
+		}
 	}
 
 	selectors, err := parseSelectors(selector)
@@ -723,9 +756,13 @@ func (fn *FilterNode) Matches(b Block) bool {
 }
 
 // BlockSelector selects blocks by kind and optional attribute/data filters.
+// RequireChild (the inline '#(...)' form) gates the parent on a descendant
+// chain without yielding it, unlike ValueExtractor.ChildSelectors which
+// terminates the outer chain and yields the descendants.
 type BlockSelector struct {
-	Kind   BlockKind
-	Filter *FilterNode `json:",omitempty"`
+	Kind         BlockKind
+	Filter       *FilterNode     `json:",omitempty"`
+	RequireChild []BlockSelector `json:",omitempty"`
 }
 
 func (bs BlockSelector) Iterator(blocks iter.Seq[Block]) iter.Seq[Block] {
@@ -808,7 +845,15 @@ func (bs BlockSelector) FilterBlocks(blocks []Block) []Block {
 }
 
 func (bs BlockSelector) Matches(b Block) bool {
-	return bs.Filter.Matches(b)
+	if !bs.Filter.Matches(b) {
+		return false
+	}
+
+	if len(bs.RequireChild) > 0 && !hasMatchingChildren(b, bs.RequireChild) {
+		return false
+	}
+
+	return true
 }
 
 var validAttributeKeys = map[string]struct{}{
@@ -1235,45 +1280,141 @@ func parseSelectors(s []byte) ([]BlockSelector, error) {
 	selectors := make([]BlockSelector, 0, len(parts))
 
 	for _, part := range parts {
-		if len(part) == 0 {
-			return nil, fmt.Errorf("empty selector part found (double dot '..')")
-		}
-
-		kindStr, attrsStr, foundParen := bytes.Cut(part, bStartParen)
-
-		var selector BlockSelector
-
-		// Set and validate BlockKind.
-		switch BlockKind(kindStr) {
-		case BlockKindMeta, BlockKindLinks, BlockKindContent:
-			selector.Kind = BlockKind(kindStr)
-		default:
-			return nil, fmt.Errorf("unknown block kind: %s", kindStr)
-		}
-
-		// If there are parentheses, parse the attributes inside them.
-		if foundParen {
-			if !bytes.HasSuffix(attrsStr, bEndParen) {
-				return nil, fmt.Errorf("mismatched parenthesis in selector: %q", part)
-			}
-
-			// Remove the trailing ')' before parsing.
-			attrsStr = bytes.TrimSpace(attrsStr[:len(attrsStr)-1])
-
-			if len(attrsStr) > 0 {
-				filter, err := parseAttributes(attrsStr)
-				if err != nil {
-					return nil, err
-				}
-
-				selector.Filter = filter
-			}
+		selector, err := parseSelectorPart(part)
+		if err != nil {
+			return nil, err
 		}
 
 		selectors = append(selectors, selector)
 	}
 
 	return selectors, nil
+}
+
+// parseSelectorPart parses: kind [ '(' filter ')' ] [ '#(' childChain ')' ].
+func parseSelectorPart(part []byte) (BlockSelector, error) {
+	if len(part) == 0 {
+		return BlockSelector{}, fmt.Errorf(
+			"empty selector part found (double dot '..')")
+	}
+
+	kindEnd := bytes.IndexAny(part, "(#")
+	if kindEnd == -1 {
+		kindEnd = len(part)
+	}
+
+	kindStr := part[:kindEnd]
+	rest := part[kindEnd:]
+
+	var selector BlockSelector
+
+	switch BlockKind(kindStr) {
+	case BlockKindMeta, BlockKindLinks, BlockKindContent:
+		selector.Kind = BlockKind(kindStr)
+	default:
+		return BlockSelector{}, fmt.Errorf("unknown block kind: %s", kindStr)
+	}
+
+	if len(rest) > 0 && rest[0] == '(' {
+		closeIdx := matchingCloseParen(rest)
+		if closeIdx == -1 {
+			return BlockSelector{}, fmt.Errorf(
+				"mismatched parenthesis in selector: %q", part)
+		}
+
+		filterBytes := bytes.TrimSpace(rest[1:closeIdx])
+
+		if len(filterBytes) > 0 {
+			filter, err := parseAttributes(filterBytes)
+			if err != nil {
+				return BlockSelector{}, err
+			}
+
+			selector.Filter = filter
+		}
+
+		rest = rest[closeIdx+1:]
+	}
+
+	if len(rest) > 0 {
+		if rest[0] != '#' {
+			return BlockSelector{}, fmt.Errorf(
+				"unexpected trailing content in selector %q: %q", part, rest)
+		}
+
+		childSelectors, after, err := parseInlineChildSelector(rest)
+		if err != nil {
+			return BlockSelector{}, fmt.Errorf("in selector %q: %w", part, err)
+		}
+
+		selector.RequireChild = childSelectors
+		rest = after
+	}
+
+	if len(rest) > 0 {
+		return BlockSelector{}, fmt.Errorf(
+			"unexpected trailing content in selector %q: %q", part, rest)
+	}
+
+	return selector, nil
+}
+
+// parseInlineChildSelector parses '#(child)' at the start of rest (which
+// must begin with '#'), returning the parsed chain and the bytes after ')'.
+func parseInlineChildSelector(rest []byte) ([]BlockSelector, []byte, error) {
+	if len(rest) < 2 || rest[1] != '(' {
+		return nil, nil, fmt.Errorf("inline child selector requires '#(...)'")
+	}
+
+	innerCloseIdx := matchingCloseParen(rest[1:])
+	if innerCloseIdx == -1 {
+		return nil, nil, fmt.Errorf("mismatched parenthesis in inline child selector")
+	}
+
+	closeIdx := 1 + innerCloseIdx
+
+	inner := bytes.TrimSpace(rest[2:closeIdx])
+	if len(inner) == 0 {
+		return nil, nil, fmt.Errorf("empty inline child selector '#()'")
+	}
+
+	childSelectors, err := parseSelectors(inner)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inline child selectors: %w", err)
+	}
+
+	return childSelectors, rest[closeIdx+1:], nil
+}
+
+// matchingCloseParen returns the index of the ')' matching the '(' at s[0],
+// or -1 if none (or on unterminated quote).
+func matchingCloseParen(s []byte) int {
+	if len(s) == 0 || s[0] != '(' {
+		return -1
+	}
+
+	depth := 0
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case bQuote:
+			end := findClosingQuote(s[i+1:])
+			if end == -1 {
+				return -1
+			}
+
+			i += end + 1
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+
+	return -1
 }
 
 // splitValueSpec splits a raw value spec (everything after the opening '{')

--- a/value_extractor_test.go
+++ b/value_extractor_test.go
@@ -3,6 +3,7 @@ package newsdoc_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ttab/newsdoc"
@@ -36,6 +37,8 @@ func TestValueExtractorParse(t *testing.T) {
 		"inline_child_end_of_chain":    ".meta(type='a')#(.links(rel='b')).data{x}",
 		"inline_child_multiple":        ".meta(type='a')#(.links(rel='b')).meta(type='c')#(.content(type='d')).data{x}",
 		"inline_child_with_terminal":   ".meta(type='a')#(.links(rel='b')).data{x}#.links(rel='d')",
+		"inline_child_two_gates":       ".meta(type='a')#(.links(rel='b'))#(.content(type='c')).data{x}",
+		"double_terminal_hash":         ".meta(type='a')#.links(rel='b').data{x}#.content(type='c')",
 		"inline_child_nested":          ".meta(type='a')#(.links(rel='b')#(.meta(type='c'))).data{x}",
 		"inline_child_multi_level":     ".meta(type='a')#(.meta(type='b').links(rel='c')).data{x}",
 		"inline_child_with_name_annot": "pick=.meta(type='a')#(.links(rel='b')):annot",
@@ -113,14 +116,6 @@ func TestValueExtractorParseErrors(t *testing.T) {
 		"empty_after_open_paren":      ".meta(type='a' ()).data{date}",
 		"attr_no_equals":              ".meta(type='a' noequals).data{date}",
 		"open_paren_eof":              "block=.meta(type='a' ()",
-		"child_selector_no_dot":       "block=.meta(type='a')#links(rel='b')",
-		"inline_empty_child":          ".meta(type='a')#().data{date}",
-		"inline_child_no_dot":         ".meta(type='a')#(links(rel='b')).data{date}",
-		"inline_child_unclosed":       ".meta(type='a')#(.links(rel='b').data{date}",
-		"trailing_hash_empty_chain":   "block=.meta(type='a')#",
-		"trailing_hash_empty_suffix":  ".meta(type='a').data{date}#",
-		"suffix_inline_child":         ".meta(type='a').data{date}#(.links(rel='b'))",
-		"suffix_unexpected_content":   ".meta(type='a').data{date}garbage",
 		"combined_empty_attr_values":  ".meta(type='a')@{}.data{date}",
 		"combined_empty_data_values":  ".meta(type='a')@{title}.data{}",
 		"combined_missing_close_attr": ".meta(type='a')@{title.data{date",
@@ -134,6 +129,70 @@ func TestValueExtractorParseErrors(t *testing.T) {
 			}
 
 			t.Logf("got expected error: %v", err)
+		})
+	}
+}
+
+// TestValueExtractorParseErrorMessages pins the specific error each
+// child-selector guard produces. Several of these guards can be reached by
+// overlapping inputs, so asserting only err != nil would not prove the
+// intended guard fired.
+func TestValueExtractorParseErrorMessages(t *testing.T) {
+	type errCase struct {
+		expr string
+		want string
+	}
+
+	cases := map[string]errCase{
+		"child_selector_no_dot": {
+			"block=.meta(type='a')#links(rel='b')",
+			"selector chain must start with '.'",
+		},
+		"inline_empty_child": {
+			".meta(type='a')#().data{date}",
+			"empty inline child selector '#()'",
+		},
+		"inline_child_no_dot": {
+			".meta(type='a')#(links(rel='b')).data{date}",
+			"selector chain must start with '.'",
+		},
+		"inline_child_unclosed": {
+			".meta(type='a')#(.links(rel='b').data{date}",
+			"mismatched parenthesis in inline child selector",
+		},
+		"trailing_hash_empty_chain": {
+			"block=.meta(type='a')#",
+			"empty child selector after '#'",
+		},
+		"trailing_hash_empty_suffix": {
+			".meta(type='a').data{date}#",
+			"empty child selector after '#'",
+		},
+		"terminal_hash_no_parent": {
+			"block=#.links(rel='b')",
+			"terminal '#' child selector requires a parent selector",
+		},
+		"suffix_inline_child": {
+			".meta(type='a').data{date}#(.links(rel='b'))",
+			"inline child selector '#(...)' is not allowed after a value spec",
+		},
+		"suffix_unexpected_content": {
+			".meta(type='a').data{date}garbage",
+			"unexpected content after value spec",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := newsdoc.ValueExtractorFromString(tc.expr)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.expr)
+			}
+
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error for %q = %q, want substring %q",
+					tc.expr, err, tc.want)
+			}
 		})
 	}
 }
@@ -1030,6 +1089,119 @@ func TestCollectInlineChildWithTerminal(t *testing.T) {
 
 	if got := results[0]["m"].Block.Title; got != "both" {
 		t.Errorf("expected 'both', got %q", got)
+	}
+}
+
+func TestCollectInlineChildTwoGates(t *testing.T) {
+	doc := newsdoc.Document{
+		Meta: []newsdoc.Block{
+			{
+				Type:    "a",
+				Title:   "both",
+				Links:   []newsdoc.Block{{Rel: "b"}},
+				Content: []newsdoc.Block{{Type: "c"}},
+			},
+			{
+				Type:  "a",
+				Title: "only-link",
+				Links: []newsdoc.Block{{Rel: "b"}},
+			},
+			{
+				Type:    "a",
+				Title:   "only-content",
+				Content: []newsdoc.Block{{Type: "c"}},
+			},
+		},
+	}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		"m=.meta(type='a')#(.links(rel='b'))#(.content(type='c'))")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (block satisfying both gates), got %d", len(results))
+	}
+
+	if got := results[0]["m"].Block.Title; got != "both" {
+		t.Errorf("expected 'both', got %q", got)
+	}
+}
+
+func TestCollectDoubleTerminalHash(t *testing.T) {
+	// A terminal '#' both in the selector chain (before the value spec) and
+	// after the value spec's '}'. Both gates must apply (regression: the
+	// second used to silently overwrite the first).
+	doc := newsdoc.Document{
+		Meta: []newsdoc.Block{
+			{
+				Type:    "a",
+				Data:    newsdoc.DataMap{"x": "kept"},
+				Links:   []newsdoc.Block{{Rel: "b"}},
+				Content: []newsdoc.Block{{Type: "c"}},
+			},
+			{
+				Type:  "a",
+				Data:  newsdoc.DataMap{"x": "only-links"},
+				Links: []newsdoc.Block{{Rel: "b"}},
+			},
+			{
+				Type:    "a",
+				Data:    newsdoc.DataMap{"x": "only-content"},
+				Content: []newsdoc.Block{{Type: "c"}},
+			},
+		},
+	}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		".meta(type='a')#.links(rel='b').data{x}#.content(type='c')")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (block satisfying both gates), got %d", len(results))
+	}
+
+	if got := results[0]["x"].Value; got != "kept" {
+		t.Errorf("expected 'kept', got %q", got)
+	}
+}
+
+func TestCollectInlineChildNested(t *testing.T) {
+	// A nested gate: the parent must have a links(rel='b') child that itself
+	// has a meta(type='c') grandchild. Exercises the recursive
+	// hasMatchingChildren path (a RequireChild inside a RequireChild), which
+	// the flat multi-level gate does not. The second block has the right
+	// child but not the grandchild, so it must be rejected.
+	withGrandchild := newsdoc.Block{
+		Type:  "a",
+		Data:  newsdoc.DataMap{"x": "match"},
+		Links: []newsdoc.Block{{Rel: "b", Meta: []newsdoc.Block{{Type: "c"}}}},
+	}
+	childOnly := newsdoc.Block{
+		Type:  "a",
+		Data:  newsdoc.DataMap{"x": "no-grandchild"},
+		Links: []newsdoc.Block{{Rel: "b"}},
+	}
+	doc := newsdoc.Document{Meta: []newsdoc.Block{withGrandchild, childOnly}}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		".meta(type='a')#(.links(rel='b')#(.meta(type='c'))).data{x}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (only the block with a grandchild), got %d", len(results))
+	}
+
+	if got := results[0]["x"].Value; got != "match" {
+		t.Errorf("expected 'match', got %q", got)
 	}
 }
 

--- a/value_extractor_test.go
+++ b/value_extractor_test.go
@@ -30,6 +30,18 @@ func TestValueExtractorParse(t *testing.T) {
 		"data_multi_mixed": ".meta(type='core/event' data.date?? data.status='confirmed').data{date}",
 		"child_selector":   "assignment=.meta(type='core/assignment')#.links(rel='deliverable' uuid='abc'):label",
 
+		// Inline per-selector child filter '#(...)'.
+		"inline_child_then_attrs":      ".meta(type='a')#(.links(rel='b')).meta(type='c')@{value}",
+		"inline_child_then_data":       ".meta(type='a')#(.links(rel='b')).meta(type='c').data{x}",
+		"inline_child_end_of_chain":    ".meta(type='a')#(.links(rel='b')).data{x}",
+		"inline_child_multiple":        ".meta(type='a')#(.links(rel='b')).meta(type='c')#(.content(type='d')).data{x}",
+		"inline_child_with_terminal":   ".meta(type='a')#(.links(rel='b')).data{x}#.links(rel='d')",
+		"inline_child_nested":          ".meta(type='a')#(.links(rel='b')#(.meta(type='c'))).data{x}",
+		"inline_child_multi_level":     ".meta(type='a')#(.meta(type='b').links(rel='c')).data{x}",
+		"inline_child_with_name_annot": "pick=.meta(type='a')#(.links(rel='b')):annot",
+		"inline_child_quoted_paren":    ".meta(type='a')#(.links(rel='b)c')).data{x}",
+		"inline_child_quoted_hash":     ".meta(type='a')#(.links(rel='b#c')).data{x}",
+
 		// Special characters and sequences inside quoted strings.
 		"quoted_hash_in_type":          ".meta(type='core/thing#v1').data{date}",
 		"quoted_hash_in_block":         "items=.meta(type='core/tagged#v2').links(rel='item')",
@@ -102,6 +114,13 @@ func TestValueExtractorParseErrors(t *testing.T) {
 		"attr_no_equals":              ".meta(type='a' noequals).data{date}",
 		"open_paren_eof":              "block=.meta(type='a' ()",
 		"child_selector_no_dot":       "block=.meta(type='a')#links(rel='b')",
+		"inline_empty_child":          ".meta(type='a')#().data{date}",
+		"inline_child_no_dot":         ".meta(type='a')#(links(rel='b')).data{date}",
+		"inline_child_unclosed":       ".meta(type='a')#(.links(rel='b').data{date}",
+		"trailing_hash_empty_chain":   "block=.meta(type='a')#",
+		"trailing_hash_empty_suffix":  ".meta(type='a').data{date}#",
+		"suffix_inline_child":         ".meta(type='a').data{date}#(.links(rel='b'))",
+		"suffix_unexpected_content":   ".meta(type='a').data{date}garbage",
 		"combined_empty_attr_values":  ".meta(type='a')@{}.data{date}",
 		"combined_empty_data_values":  ".meta(type='a')@{title}.data{}",
 		"combined_missing_close_attr": ".meta(type='a')@{title.data{date",
@@ -841,6 +860,248 @@ func TestCollectDataFilterExists(t *testing.T) {
 	results := ve.Collect(doc)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result (only block with status key), got %d", len(results))
+	}
+}
+
+func TestCollectInlineChildSelector(t *testing.T) {
+	doc := newsdoc.Document{
+		Meta: []newsdoc.Block{
+			{
+				Type: "core/assignment",
+				Links: []newsdoc.Block{
+					{Type: "core/article", Rel: "deliverable"},
+				},
+				Meta: []newsdoc.Block{
+					{Type: "tt/slugline", Value: "slug-A"},
+				},
+			},
+			{
+				Type: "core/assignment",
+				Links: []newsdoc.Block{
+					{Type: "core/article", Rel: "other"},
+				},
+				Meta: []newsdoc.Block{
+					{Type: "tt/slugline", Value: "slug-B"},
+				},
+			},
+		},
+	}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		".meta(type='core/assignment')#(.links(rel='deliverable')).meta(type='tt/slugline')@{value}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (slugline from assignment with deliverable), got %d", len(results))
+	}
+
+	if got := results[0]["value"].Value; got != "slug-A" {
+		t.Errorf("expected 'slug-A', got %q", got)
+	}
+
+	veNone, err := newsdoc.ValueExtractorFromString(
+		".meta(type='core/assignment')#(.links(rel='nonesuch')).meta(type='tt/slugline')@{value}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if got := veNone.Collect(doc); len(got) != 0 {
+		t.Fatalf("expected 0 results when inline filter matches nothing, got %d", len(got))
+	}
+}
+
+func TestCollectInlineChildEndOfChain(t *testing.T) {
+	doc := newsdoc.Document{
+		Meta: []newsdoc.Block{
+			{
+				Type:  "a",
+				Data:  newsdoc.DataMap{"x": "kept"},
+				Links: []newsdoc.Block{{Rel: "b"}},
+			},
+			{
+				Type:  "a",
+				Data:  newsdoc.DataMap{"x": "filtered"},
+				Links: []newsdoc.Block{{Rel: "other"}},
+			},
+		},
+	}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		".meta(type='a')#(.links(rel='b')).data{x}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if got := results[0]["x"].Value; got != "kept" {
+		t.Errorf("expected 'kept', got %q", got)
+	}
+}
+
+func TestCollectInlineChildMultiLevel(t *testing.T) {
+	doc := newsdoc.Document{
+		Meta: []newsdoc.Block{
+			{
+				Type: "a",
+				Data: newsdoc.DataMap{"x": "matches"},
+				Meta: []newsdoc.Block{
+					{
+						Type:  "b",
+						Links: []newsdoc.Block{{Rel: "c"}},
+					},
+				},
+			},
+			{
+				Type: "a",
+				Data: newsdoc.DataMap{"x": "shallow-b-only"},
+				Meta: []newsdoc.Block{{Type: "b"}},
+			},
+			{
+				Type: "a",
+				Data: newsdoc.DataMap{"x": "wrong-meta-type"},
+				Meta: []newsdoc.Block{
+					{
+						Type:  "z",
+						Links: []newsdoc.Block{{Rel: "c"}},
+					},
+				},
+			},
+		},
+	}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		".meta(type='a')#(.meta(type='b').links(rel='c')).data{x}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if got := results[0]["x"].Value; got != "matches" {
+		t.Errorf("expected 'matches', got %q", got)
+	}
+}
+
+func TestCollectInlineChildWithTerminal(t *testing.T) {
+	doc := newsdoc.Document{
+		Meta: []newsdoc.Block{
+			{
+				Type:  "a",
+				Title: "both",
+				Links: []newsdoc.Block{{Rel: "b"}, {Rel: "d"}},
+			},
+			{
+				Type:  "a",
+				Title: "only-inline",
+				Links: []newsdoc.Block{{Rel: "b"}},
+			},
+			{
+				Type:  "a",
+				Title: "only-terminal",
+				Links: []newsdoc.Block{{Rel: "d"}},
+			},
+			{
+				Type:  "a",
+				Title: "neither",
+			},
+		},
+	}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		"m=.meta(type='a')#(.links(rel='b'))#.links(rel='d')")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (block satisfying both gates), got %d", len(results))
+	}
+
+	if got := results[0]["m"].Block.Title; got != "both" {
+		t.Errorf("expected 'both', got %q", got)
+	}
+}
+
+func TestCollectInlineChildOnLinksOuter(t *testing.T) {
+	doc := newsdoc.Document{
+		Links: []newsdoc.Block{
+			{
+				Rel:   "associated",
+				Title: "with-meta",
+				Meta:  []newsdoc.Block{{Type: "core/note"}},
+			},
+			{
+				Rel:   "associated",
+				Title: "without-meta",
+			},
+		},
+	}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		"link=.links(rel='associated')#(.meta(type='core/note'))")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if got := results[0]["link"].Block.Title; got != "with-meta" {
+		t.Errorf("expected 'with-meta', got %q", got)
+	}
+}
+
+func TestCollectInlineChildWithDataFilter(t *testing.T) {
+	doc := newsdoc.Document{
+		Meta: []newsdoc.Block{
+			{
+				Type:  "a",
+				Title: "active",
+				Links: []newsdoc.Block{
+					{Rel: "b", Data: newsdoc.DataMap{"status": "ok"}},
+				},
+			},
+			{
+				Type:  "a",
+				Title: "inactive",
+				Links: []newsdoc.Block{
+					{Rel: "b", Data: newsdoc.DataMap{"status": "stale"}},
+				},
+			},
+			{
+				Type:  "a",
+				Title: "no-status",
+				Links: []newsdoc.Block{{Rel: "b"}},
+			},
+		},
+	}
+
+	ve, err := newsdoc.ValueExtractorFromString(
+		"m=.meta(type='a')#(.links(rel='b' data.status='ok'))")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	results := ve.Collect(doc)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (only 'active' matches), got %d", len(results))
+	}
+
+	if got := results[0]["m"].Block.Title; got != "active" {
+		t.Errorf("expected 'active', got %q", got)
 	}
 }
 


### PR DESCRIPTION
## What

Adds an **inline child selector** `#(...)` to the value-extractor expression language. It gates a single selector on the existence of matching descendants *without* terminating the outer chain or changing what's yielded — unlike the existing terminal `#`, which ends the chain and yields the descendants instead.

This fills a gap: previously you couldn't constrain a block by its descendants and then keep navigating deeper.

```
.meta(type='core/assignment')#(.links(rel='deliverable')).meta(type='tt/slugline')@{value}
```

Matches `core/assignment` meta blocks that have a `deliverable` link, then navigates into each match's `tt/slugline` meta block and extracts the `value` attribute.

## Changes

- Add `BlockSelector.RequireChild`, evaluated via the existing `hasMatchingChildren` in `BlockSelector.Matches`; supports nesting and the same filters as the terminal form.
- Replace `indexByteOutsideQuotes` with `terminalHashIndex` (quote- and paren-depth-aware) so a terminal `#` is distinguished from an inline `#(`.
- Extract `parseSelectorPart`, `parseInlineChildSelector`, and `matchingCloseParen` for readable selector-part parsing.
- Reject inline `#(...)` after a value spec, and error on unexpected trailing content after a value spec (**behavior change**: previously silently ignored).
- Document the inline form in `README.md` and add parse, parse-error, and `Collect` test coverage with golden fixtures.

## Verification

- `go build ./...` ✓
- `go test ./...` ✓
- `golangci-lint run --timeout=4m` → 0 issues ✓
- `REGENERATE=true go test ./...` → no drift in tracked golden files ✓

`doc.go` is untouched, so no `make generate` is needed (`BlockSelector` is an internal extractor type, not part of the wire schema).